### PR TITLE
Fixed webhook section

### DIFF
--- a/imagoweb/config.example.yml
+++ b/imagoweb/config.example.yml
@@ -257,8 +257,9 @@ discord:
 
     # you may list as many as you like    
     webhooks:
-        - url: https://discordapp.com/api/webhooks/channel/token
-          username: Imago Dashboard
+        - id: 123456789
+          token: ABCDEFGHIJ12345
+          username: Imago CDN
 
           events:
             - FILE_DELETE # file deleted by its owner


### PR DESCRIPTION
- Changed URL into it's respected "id" and "token" sections, as using the "url" section causes the following error:

```
Traceback (most recent call last):
  File "imago.py", line 36, in <module>
    from imagoweb.util import console, constants
  File "../imagoweb/util/__init__.py", line 15, in <module>
    from .constants import *
  File "../imagoweb/util/constants.py", line 46, in <module>
    webhooks=[webhook(**hook) for hook in config.discord.webhooks if config.discord.enabled]))
  File "../imagoweb/util/constants.py", line 46, in <listcomp>
    webhooks=[webhook(**hook) for hook in config.discord.webhooks if config.discord.enabled]))
  File "../imagoweb/util/blueprints.py", line 55, in __init__
    self.hook_id = webhook_data.pop("id")
KeyError: 'id'
```